### PR TITLE
chore(deps): update pnpm to 10.33.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript": "^6.0.3",
     "ultracite": "^7.7.0"
   },
-  "packageManager": "pnpm@10.29.3",
+  "packageManager": "pnpm@10.33.4",
   "pnpm": {
     "overrides": {
       "postcss": "8.5.15"


### PR DESCRIPTION
## Summary
- update `packageManager` from `pnpm@10.29.3` to `pnpm@10.33.4`
- chose `10.33.4` instead of newer `10.34.1` because of the 7-day npm publish-age rule

## 7-day npm rule
- `pnpm@10.33.4` published: 2026-05-06T13:17:10.682Z
- maintenance run time: 2026-05-28 00:30 UTC
- age: >21 days, qualifies

## Verification
- `npx -y pnpm@10.33.4 install --frozen-lockfile`
- `npx -y pnpm@10.33.4 lint`
- `npx -y pnpm@10.33.4 build`

## Notes
- `pnpm@10.34.1` is too new for today (published 2026-05-27T23:03:31.140Z), so Renovate PR #120 should wait or be retargeted later.
