### PR TITLE
chore(deps): update actions labeler to v6

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true


### PR DESCRIPTION
## Summary\n- update actions/labeler from v5 to v6.1.0\n\n## Verification\n- checked actions/labeler latest release: v6.1.0 published 2026-05-06\n- inspected workflow diff only; no runtime code changes\n\n## Notes\n- npm package updates remain under the 7-day stability hold where applicable