### PR TITLE
chore(deps): update dayjs to 1.11.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.12",
-    "dayjs": "^1.11.20",
+    "dayjs": "^1.11.21",
     "next": "^16.2.6",
     "next-themes": "^0.4.6",
     "react": "^19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       dayjs:
-        specifier: ^1.11.20
+        specifier: ^1.11.21
         version: 1.11.21
       next:
         specifier: ^16.2.6


### PR DESCRIPTION
Maintainer daily dependency update.\n\n- Updates locked `dayjs` version to `1.11.21` within the existing `^1.11.20` range\n- npm 7-day rule: `1.11.21` published 2026-05-26T05:46:12.427Z, older than 7 full days at 2026-06-04T00:30:00Z\n- Verification: `pnpm install --frozen-lockfile --ignore-scripts`, `pnpm lint`, `pnpm build` passed locally