### PR TITLE
chore(deps): upgrade all dependencies to latest major versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,37 +16,32 @@
     "*.{js,jsx,ts,tsx,json,jsonc,css}": "pnpm dlx ultracite fix"
   },
   "dependencies": {
-    "@radix-ui/react-accordion": "^1.2.12",
+    "@radix-ui/react-accordion": "^1.2.13",
     "dayjs": "^1.11.21",
-    "next": "^16.2.6",
+    "next": "^16.2.7",
     "next-themes": "^0.4.6",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.15",
+    "@biomejs/biome": "^2.4.16",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
-    "@next/mdx": "^16.2.6",
+    "@next/mdx": "^16.2.7",
     "@tailwindcss/postcss": "^4.3.0",
-    "@types/mdx": "^2.0.13",
-    "@types/node": "^25.8.0",
-    "@types/react": "^19.2.14",
+    "@types/mdx": "^2.0.14",
+    "@types/node": "^25.9.2",
+    "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "husky": "^9.1.7",
-    "lint-staged": "^17.0.5",
+    "lint-staged": "^17.0.7",
     "postcss": "^8.5.15",
     "remark-gfm": "^4.0.1",
-    "shiki": "^4.0.2",
+    "shiki": "^4.2.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
-    "ultracite": "^7.7.0"
+    "ultracite": "^7.8.2"
   },
-  "packageManager": "pnpm@10.34.1",
-  "pnpm": {
-    "overrides": {
-      "postcss": "8.5.15"
-    }
-  }
+  "packageManager": "pnpm@11.5.2"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,29 +12,29 @@ importers:
   .:
     dependencies:
       '@radix-ui/react-accordion':
-        specifier: ^1.2.12
+        specifier: ^1.2.13
         version: 1.2.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       dayjs:
         specifier: ^1.11.21
         version: 1.11.21
       next:
-        specifier: ^16.2.6
+        specifier: ^16.2.7
         version: 16.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
-        specifier: ^19.2.6
+        specifier: ^19.2.7
         version: 19.2.7
       react-dom:
-        specifier: ^19.2.6
+        specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.4.15
+        specifier: ^2.4.16
         version: 2.4.16
       '@mdx-js/loader':
         specifier: ^3.1.1
@@ -43,19 +43,19 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.17)(react@19.2.7)
       '@next/mdx':
-        specifier: ^16.2.6
+        specifier: ^16.2.7
         version: 16.2.7(@mdx-js/loader@3.1.1)(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
       '@types/mdx':
-        specifier: ^2.0.13
+        specifier: ^2.0.14
         version: 2.0.14
       '@types/node':
-        specifier: ^25.8.0
+        specifier: ^25.9.2
         version: 25.9.2
       '@types/react':
-        specifier: ^19.2.14
+        specifier: ^19.2.17
         version: 19.2.17
       '@types/react-dom':
         specifier: ^19.2.3
@@ -64,7 +64,7 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       lint-staged:
-        specifier: ^17.0.5
+        specifier: ^17.0.7
         version: 17.0.7
       postcss:
         specifier: 8.5.15
@@ -73,7 +73,7 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       shiki:
-        specifier: ^4.0.2
+        specifier: ^4.2.0
         version: 4.2.0
       tailwindcss:
         specifier: ^4.3.0
@@ -82,7 +82,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       ultracite:
-        specifier: ^7.7.0
+        specifier: ^7.8.2
         version: 7.8.2
 
 packages:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  sharp: true
+
+overrides:
+  postcss: 8.5.15


### PR DESCRIPTION
## Dependency Upgrades

### Dependencies
| Package | From | To |
|---------|------|----|
| @radix-ui/react-accordion | ^1.2.12 | ^1.2.13 |
| next | ^16.2.6 | ^16.2.7 |
| react | ^16.2.6 | ^19.2.7 |
| react-dom | ^19.2.6 | ^19.2.7 |

### Dev Dependencies
| Package | From | To |
|---------|------|----|
| @biomejs/biome | ^2.4.15 | ^2.4.16 |
| @next/mdx | ^16.2.6 | ^16.2.7 |
| @types/mdx | ^2.0.13 | ^2.0.14 |
| @types/node | ^25.8.0 | ^25.9.2 |
| @types/react | ^19.2.14 | ^19.2.17 |
| lint-staged | ^17.0.5 | ^17.0.7 |
| shiki | ^4.0.2 | ^4.2.0 |
| ultracite | ^7.7.0 | ^7.8.2 |

### Tooling
| Package | From | To |
|---------|------|----|
| pnpm (packageManager) | 10.34.1 | 11.5.2 |

### Additional Changes
- Migrated `pnpm.overrides` from `package.json` to `pnpm-workspace.yaml` (required by pnpm v11)
- Created `pnpm-workspace.yaml` with `allowBuilds` and `overrides` config

### Verification
- ✅ `pnpm install` succeeds
- ✅ `pnpm build` succeeds (Next.js 16.2.7, Turbopack)

Closes #116 (supersedes the renovate pnpm v11 upgrade PR)