### PR TITLE
chore(deps): update eligible semantic deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "*.{js,jsx,ts,tsx,json,jsonc,css}": "pnpm dlx ultracite fix"
   },
   "dependencies": {
-    "@radix-ui/react-accordion": "^1.2.13",
+    "@radix-ui/react-accordion": "^1.2.14",
     "dayjs": "^1.11.21",
     "next": "16.2.9",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
   .:
     dependencies:
       '@radix-ui/react-accordion':
-        specifier: ^1.2.13
+        specifier: ^1.2.14
         version: 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       dayjs:
         specifier: ^1.11.21
@@ -842,8 +842,8 @@ packages:
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
-  enhanced-resolve@5.24.0:
-    resolution: {integrity: sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==}
+  enhanced-resolve@5.21.6:
+    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
 
   environment@1.1.0:
@@ -1959,7 +1959,7 @@ snapshots:
   '@tailwindcss/node@4.3.1':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.24.0
+      enhanced-resolve: 5.21.6
       jiti: 2.7.0
       lightningcss: 1.32.0
       magic-string: 0.30.21
@@ -2152,7 +2152,7 @@ snapshots:
 
   emoji-regex@10.6.0: {}
 
-  enhanced-resolve@5.24.0:
+  enhanced-resolve@5.21.6:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3


### PR DESCRIPTION
## Summary
- Update `@radix-ui/react-accordion` to `^1.2.14`
- Refresh `pnpm-lock.yaml` so already-eligible package.json versions resolve in lockfile
- Avoid current Renovate updates that violate the 7-day npm publish window

## npm 7-day rule
Run time: 2026-06-25 00:30 UTC; cutoff: 2026-06-18 00:30 UTC.
Verified changed/new versions are older than 7 full days:
- `@radix-ui/react-accordion@1.2.14` — 2026-06-15T19:09:38.173Z
- `@radix-ui/react-collapsible@1.1.14` — 2026-06-15T19:08:45.579Z
- `@radix-ui/react-collection@1.1.10` — 2026-06-15T19:08:48.938Z
- `@radix-ui/react-primitive@2.1.6` — 2026-06-15T19:08:23.846Z
- `@radix-ui/react-slot@1.3.0` — 2026-06-15T19:08:19.819Z
- `enhanced-resolve@5.21.6` — 2026-05-20T16:15:44.083Z

## Verification
- `pnpm lint` passed (`ultracite check`, 65 files)
- `pnpm build` passed (`next build`, Next.js 16.2.9)