### PR TITLE
chore(deps): update pnpm to 11.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,5 @@
     "typescript": "^6.0.3",
     "ultracite": "7.8.3"
   },
-  "packageManager": "pnpm@11.6.0"
+  "packageManager": "pnpm@11.8.0"
 }


### PR DESCRIPTION
## Summary
- Update `packageManager` from `pnpm@11.6.0` to `pnpm@11.8.0`.
- Held back from `pnpm@11.9.0` because it was published on 2026-06-23T15:43:46.512Z and is not 7 full days old at the 2026-06-26 maintenance run.

## npm 7-day rule evidence
- `pnpm@11.8.0` published: 2026-06-18T10:30:09.204Z (eligible; older than cutoff 2026-06-19T00:30:00Z)
- `pnpm@11.9.0` published: 2026-06-23T15:43:46.512Z (not eligible)

## Verification
- `pnpm lint`
- `pnpm build`
