### PR TITLE
chore(deps): update Node types

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@next/mdx": "16.2.9",
     "@tailwindcss/postcss": "4.3.1",
     "@types/mdx": "^2.0.14",
-    "@types/node": "25.9.4",
+    "@types/node": "26.0.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: ^2.0.14
         version: 2.0.14
       '@types/node':
-        specifier: 25.9.4
-        version: 25.9.4
+        specifier: 26.0.1
+        version: 26.0.1
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -698,8 +698,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@25.9.4':
-    resolution: {integrity: sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==}
+  '@types/node@26.0.1':
+    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1492,8 +1492,8 @@ packages:
       oxlint:
         optional: true
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -2047,9 +2047,9 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@25.9.4':
+  '@types/node@26.0.1':
     dependencies:
-      undici-types: 7.24.6
+      undici-types: 8.3.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
@@ -3162,7 +3162,7 @@ snapshots:
       yaml: 2.9.0
       zod: 4.4.3
 
-  undici-types@7.24.6: {}
+  undici-types@8.3.0: {}
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
## Summary
- Update `@types/node` from 25.9.4 to 26.0.1.
- Refresh `pnpm-lock.yaml` with `undici-types` 8.3.0.

## npm 7-day rule
- Current run time: 2026-07-05 00:30 UTC.
- `@types/node@26.0.1` published 2026-06-24T20:33:01.352Z, older than 7 full days.
- `undici-types@8.3.0` published 2026-05-14T17:06:13.732Z, older than 7 full days.
- Newer `@types/node@26.1.0` was skipped because it was published 2026-07-01T11:04:10.429Z.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm build`
