### PR TITLE
chore(deps): refresh accordion spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "*.{js,jsx,ts,tsx,json,jsonc,css}": "pnpm dlx ultracite fix"
   },
   "dependencies": {
-    "@radix-ui/react-accordion": "^1.2.15",
+    "@radix-ui/react-accordion": "^1.2.16",
     "dayjs": "^1.11.21",
     "next": "16.2.10",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
   .:
     dependencies:
       '@radix-ui/react-accordion':
-        specifier: ^1.2.15
+        specifier: ^1.2.16
         version: 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       dayjs:
         specifier: ^1.11.21


### PR DESCRIPTION
## Summary
- Refresh @radix-ui/react-accordion package spec to the already-resolved lockfile version 1.2.16.
- Keep the existing pnpm lockfile style; no runtime code changes.

## npm 7-day rule
Cutoff: 2026-07-08T00:30:00Z.
- @radix-ui/react-accordion@1.2.16 published 2026-07-06T22:06:08.793Z, so it is older than 7 full days at maintenance time.

## Verification
- pnpm install --lockfile-only: pass
- pnpm audit --json: pass / 0 vulnerabilities
- pnpm lint: pass
- pnpm build: pass
